### PR TITLE
Fixed an issue where incompatible feeds were shown in Feed Forge Processing.

### DIFF
--- a/class-gwiz-gf-feed-forge.php
+++ b/class-gwiz-gf-feed-forge.php
@@ -267,7 +267,11 @@ class GWiz_GF_Feed_Forge extends GFAddOn {
 	 * Modal markup.
 	 */
 	public function modal_markup() {
-		$feeds = self::addon_feeds();
+		// Get all feeds, except Gravity Flow.
+		$feeds = array_filter( self::addon_feeds(), function( $feed ) {
+			return rgar( $feed, 'addon_slug' ) != 'gravityflow';
+		});		
+		
 		?>
 		<div id="feeds_modal_container" style="display:none;">
 			<div id="feeds_container">


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2837058733/77542

## Summary
Excluding Gravity Flow workflow steps for now from GFFF.

**BEFORE (and none of the workflow steps functionally process):**
<img width="602" alt="Screenshot 2025-02-06 at 5 21 34 PM" src="https://github.com/user-attachments/assets/ca81b1f9-16f0-40e0-9b04-4d8ccf614fd6" />

**AFTER (all workflow steps hidden from GFFF processing):**
<img width="594" alt="Screenshot 2025-02-06 at 5 21 20 PM" src="https://github.com/user-attachments/assets/10c9d282-5a65-4953-8a42-1d4ba044131e" />
