### PR TITLE
Fixed an issue with reprocessing feed logic.

### DIFF
--- a/assets/js/gf-feed-forge-admin.js
+++ b/assets/js/gf-feed-forge-admin.js
@@ -37,7 +37,7 @@ jQuery(function($) {
 		$('.gform_feeds:checked').not('#reprocess_feeds').each(function () {
 			selectedFeeds.push($(this).val());
 		});
-console.log(selectedFeeds);
+
 		var leadIds = getLeadIds();
 
 		if (selectedFeeds.length <= 0) {

--- a/assets/js/gf-feed-forge-admin.js
+++ b/assets/js/gf-feed-forge-admin.js
@@ -34,10 +34,10 @@ jQuery(function($) {
 	$('input[name="feed_process"]').on('click', function () {
 		var selectedFeeds = [];
 
-		$('.gform_feeds:checked').each(function () {
+		$('.gform_feeds:checked').not('#reprocess_feeds').each(function () {
 			selectedFeeds.push($(this).val());
 		});
-
+console.log(selectedFeeds);
 		var leadIds = getLeadIds();
 
 		if (selectedFeeds.length <= 0) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): Not directly related to https://secure.helpscout.net/conversation/2834536109/77382

## Summary

With this PR https://github.com/gravitywiz/gf-feed-forge/pull/5, we added the reprocess feeds UI checkbox. The jquery logic here would wrongly pick that as well. Though, I think it would not cause any ill effects in processing, it is just logically sound to have it removed from the feed processing logic. "Reprocess feeds" is just a "flag" and not pointing to an exact feed per se.