### PR TITLE
Removed gravity forms coupons feeds from the process feeds list.

### DIFF
--- a/class-gwiz-gf-feed-forge.php
+++ b/class-gwiz-gf-feed-forge.php
@@ -267,11 +267,15 @@ class GWiz_GF_Feed_Forge extends GFAddOn {
 	 * Modal markup.
 	 */
 	public function modal_markup() {
-		// Get all feeds, except Gravity Flow.
-		$feeds = array_filter( self::addon_feeds(), function( $feed ) {
-			return rgar( $feed, 'addon_slug' ) != 'gravityflow';
-		});		
-		
+		// Make a list of all the feeds that are not supported by Feed Forge.
+		$unsupported_feeds = array(
+			'gravityflow',
+			'gravityformscoupons',
+		);
+
+		$feeds = array_filter( self::addon_feeds(), function ( $feed ) use ( $unsupported_feeds ) {
+			return ! in_array( rgar( $feed, 'addon_slug' ), $unsupported_feeds );
+		} );
 		?>
 		<div id="feeds_modal_container" style="display:none;">
 			<div id="feeds_container">


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2859652281/78587

## Summary

GF feed forge shows the feeds of coupons when selecting the feed to process. This PR fixes this issue.

Here's a video demo of the issue: 

https://www.loom.com/share/cc5f7cc6c18947ecb7e220c1114a0413?sid=7032146d-4754-4ecc-9171-0348f13a3840

## Checklist

- [ ] Updated customer telling them that a fix/addition is in the works.
- [ ] Added/Improved Cypress tests or a note under _Summary_ why tests are not included in the PR.
- [ ] Added a link to this PR in the Help Scout ticket(s) in the form of a note
- [ ] Added/updated hook documentation if applicable.
- [ ] Sent a [packed build](https://www.notion.so/gravitywiz/GWiz-Builder-de063e85494e4a8aace9994a3ef793f9#9de8bd246edb4d108324e5eb32b4d597) of this PR/branch for the customer to test.

### After approval by customer and code review passing.

- [ ] Merged PR
- [ ] Created new build using [](https://www.notion.so/gravitywiz/GWiz-Builder-de063e85494e4a8aace9994a3ef793f9#2477848f38214092af36b13df6506003)
- [ ] Notify David of any required documentation changes (e.g. UX changes) by tagging him via GitHub.
- [ ] Notified customer that the change has been merged in and that it will be going out to the auto-updater (if applicable).
