### PR TITLE
Fixed compatibility issue with Gravity Forms v2.9.7 when processing feeds.

### DIFF
--- a/class-gwiz-gf-feed-forge.php
+++ b/class-gwiz-gf-feed-forge.php
@@ -384,6 +384,8 @@ class GWiz_GF_Feed_Forge extends GFAddOn {
 		$leads   = rgpost( 'leadIds' );
 		$feeds   = json_decode( rgpost( 'feeds' ) );
 
+		$_REQUEST['nonce'] = wp_create_nonce( 'wp_gf_feed_processor' );
+
 		// Ensure that the form ID is provided.
 		if ( empty( $form_id ) ) {
 			wp_send_json_error( array(


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2916752396/82500
https://secure.helpscout.net/conversation/2893173165/81535

## Summary

Gravity Forms v2.9.7 broke GFFF. This is down to this commit https://github.com/gravityforms/gravityforms/pull/3196

The Gravity Forms feed processor requires a nonce with identifier wp_gf_feed_processor, which wasn't being provided.

If we see the debugger, the following code is where the fatal error got trigerred:

<img width="1647" alt="Screenshot 2025-04-26 at 6 35 15 AM" src="https://github.com/user-attachments/assets/3ad6a7f7-f6ac-4706-9775-d49fb0a1c90b" />

This PR adds nonce generation for `wp_gf_feed_processor` before dispatch.

<img width="800" alt="Screenshot 2025-04-26 at 6 33 20 AM" src="https://github.com/user-attachments/assets/692fdf6b-a6f6-4843-b669-07b1e2af9446" />

<img width="800" alt="Screenshot 2025-04-26 at 6 33 36 AM" src="https://github.com/user-attachments/assets/7a952e09-95fa-4ee1-bce0-cf947161162f" />


PS: Gravity Forms have a PR open for namespacing `GF_Background_Process` (which is where our GFFF code failed). PR link: https://github.com/gravityforms/gravityforms/pull/3208. We can confirm that this fix does not cause any issues with GFFF, because basically this new fix just has to do with some namespacing and refactoring.