### PR TITLE
Added filter `gfff_include_inactive_feeds` to allow inclusion of inactive feeds during processing.

### DIFF
--- a/class-gwiz-gf-feed-forge.php
+++ b/class-gwiz-gf-feed-forge.php
@@ -354,14 +354,14 @@ class GWiz_GF_Feed_Forge extends GFAddOn {
 		 *
 		 * @param bool $include_inactive Whether to include inactive feeds. Defaults to false.
 		 * @param int  $form_id          The ID of the current form.
-		 * 
+		 *
 		 * @since 1.1.9
 		 */
 		$include_inactive = gf_apply_filters( array( 'gfff_include_inactive_feeds', $form_id ), false );
 		// If the filter is true, we pass `null` to the API to get all feeds.
 		// Otherwise, we pass `true` to get only active feeds.
-		$is_active_param  = $include_inactive ? null : true;
-		$feeds            = GFAPI::get_feeds( null, $form_id, null, $is_active_param );
+		$is_active_param = $include_inactive ? null : true;
+		$feeds           = GFAPI::get_feeds( null, $form_id, null, $is_active_param );
 
 		foreach ( $feeds as $feed ) {
 			if ( isset( $feed['addon_slug'] ) && in_array( $feed['addon_slug'], $slugs, true ) ) {

--- a/class-gwiz-gf-feed-forge.php
+++ b/class-gwiz-gf-feed-forge.php
@@ -347,10 +347,23 @@ class GWiz_GF_Feed_Forge extends GFAddOn {
 		$form_id     = rgget( 'id' );
 		$addons      = self::registered_addons();
 		$slugs       = array_keys( $addons );
-		$feeds       = GFAPI::get_feeds( null, $form_id );
 		$addon_feeds = [];
 
-		foreach ( $feeds  as $feed ) {
+		/**
+		 * Filter whether to include inactive feeds in the feed list.
+		 *
+		 * @param bool $include_inactive Whether to include inactive feeds. Defaults to false.
+		 * @param int  $form_id          The ID of the current form.
+		 * 
+		 * @since 1.1.9
+		 */
+		$include_inactive = gf_apply_filters( array( 'gfff_include_inactive_feeds', $form_id ), false );
+		// If the filter is true, we pass `null` to the API to get all feeds.
+		// Otherwise, we pass `true` to get only active feeds.
+		$is_active_param  = $include_inactive ? null : true;
+		$feeds            = GFAPI::get_feeds( null, $form_id, null, $is_active_param );
+
+		foreach ( $feeds as $feed ) {
 			if ( isset( $feed['addon_slug'] ) && in_array( $feed['addon_slug'], $slugs, true ) ) {
 				$feed['title'] = $addons[ $feed['addon_slug'] ]->get_short_title();
 				$addon_feeds[] = $feed;


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2986479718/85973?viewId=8172236

## Summary

Customer requested a snippet that would allow them to process entries for inactive feeds on an on-demand basis, similar to how they use inactive notifications.

Added `gfff_include_inactive_feeds` filter, which enable users to override the default behavior of only showing active feeds.

**Example usage:**
```
// All forms
add_filter( 'gfff_include_inactive_feeds', '__return_true' );
```

```
// Specific form
add_filter( 'gfff_include_inactive_feeds_123', '__return_true' );
```

[Hook documentation](https://gravitywiz.com/?post_type=documentation&p=1354247&preview=true)

## Checklist

- [x] Updated customer telling them that a fix/addition is in the works.
- [ ] Added/Improved Cypress tests or a note under _Summary_ why tests are not included in the PR.
- [x] Added a link to this PR in the Help Scout ticket(s) in the form of a note
- [ ] Added/updated hook documentation if applicable.
- [ ] Sent a [packed build](https://www.notion.so/gravitywiz/GWiz-Builder-de063e85494e4a8aace9994a3ef793f9#9de8bd246edb4d108324e5eb32b4d597) of this PR/branch for the customer to test.