### PR TITLE
Passed `--no-scripts` flag to `composer` during GH lint check.

### DIFF
--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -11,7 +11,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer install --dev --prefer-dist --no-progress --no-suggest
-          composer require --dev staabm/annotate-pull-request-from-checkstyle
+          composer install --no-scripts --dev --prefer-dist --no-progress --no-suggest
+          composer require --no-scripts --dev staabm/annotate-pull-request-from-checkstyle
       - name: Run phpcs
         run: ./vendor/bin/phpcs -q --report=checkstyle | ./vendor/bin/cs2pr --graceful-warnings


### PR DESCRIPTION
## Context

https://github.com/gravitywiz/gf-feed-forge/pull/13/files

## Summary

Fixing an issue with the lint check.

## Checklist

- [ ] Updated customer telling them that a fix/addition is in the works.
- [ ] Added/Improved Cypress tests or a note under _Summary_ why tests are not included in the PR.
- [ ] Added a link to this PR in the Help Scout ticket(s) in the form of a note
- [ ] Added/updated hook documentation if applicable.
- [ ] Sent a [packed build](https://www.notion.so/gravitywiz/GWiz-Builder-de063e85494e4a8aace9994a3ef793f9#9de8bd246edb4d108324e5eb32b4d597) of this PR/branch for the customer to test.

### After approval by customer and code review passing.

- [ ] Merged PR
- [ ] Created new build using [](https://www.notion.so/gravitywiz/GWiz-Builder-de063e85494e4a8aace9994a3ef793f9#2477848f38214092af36b13df6506003)
- [ ] Notify David of any required documentation changes (e.g. UX changes) by tagging him via GitHub.
- [ ] Notified customer that the change has been merged in and that it will be going out to the auto-updater (if applicable).
