### PR TITLE
Added support for `gform_addon_pre_process_feeds` filter.

### DIFF
--- a/class-gwiz-gf-feed-forge.php
+++ b/class-gwiz-gf-feed-forge.php
@@ -558,6 +558,19 @@ class GWiz_GF_Feed_Forge extends GFAddOn {
 					self::clear_processed_feeds( $entry_id, $feed, $addon );
 				}
 
+				// Apply gform_addon_pre_process_feeds filters to allow feed modification before processing
+				$feeds_to_process = apply_filters( 'gform_addon_pre_process_feeds', array( $feed ), $entry, $form );
+				$feeds_to_process = apply_filters( "gform_addon_pre_process_feeds_{$form_id}", $feeds_to_process, $entry, $form );
+				$feeds_to_process = apply_filters( "gform_{$addon->get_slug()}_pre_process_feeds", $feeds_to_process, $entry, $form );
+				$feeds_to_process = apply_filters( "gform_{$addon->get_slug()}_pre_process_feeds_{$form_id}", $feeds_to_process, $entry, $form );
+
+				// Skip if filters removed the feed or returned invalid data
+				if ( empty( $feeds_to_process ) || ! is_array( $feeds_to_process ) ) {
+					continue;
+				}
+
+				$feed = $feeds_to_process[0];
+
 				gf_feed_processor()->push_to_queue(
 					[
 						'addon'    => $addon,


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3020279861/87164?viewId=3808239

## Summary

This PR adds support for `gform_addon_pre_process_feeds` filter and its variants. This allows users to modify their feeds before bulk processing when using Feed Forge.

Updated `process_entry_feeds()` method to apply the filters before queuing feeds.

**Quick demo: https://www.loom.com/share/6ff3d6f3f299465e94909043154b05c7**

- [ ] Updated customer telling them that a fix/addition is in the works.
- [ ] Added/Improved Cypress tests or a note under _Summary_ why tests are not included in the PR.
- [x] Added a link to this PR in the Help Scout ticket(s) in the form of a note
- [ ] Added/updated hook documentation if applicable.
- [ ] Sent a [packed build](https://www.notion.so/gravitywiz/GWiz-Builder-de063e85494e4a8aace9994a3ef793f9#9de8bd246edb4d108324e5eb32b4d597) of this PR/branch for the customer to test.