### PR TITLE
Fixed an issue where clicking a bottom feed in a scrolled list caused the modal layout to shift.

### DIFF
--- a/assets/js/gf-feed-forge-admin.js
+++ b/assets/js/gf-feed-forge-admin.js
@@ -49,7 +49,7 @@ jQuery(function($) {
 			$('#gfff-progress-bar').hide();
 			$('#gfff-progress-bar span').width('0');
 
-			jQuery('#TB_ajaxContent').css('overflow', 'hidden');
+			jQuery('#TB_ajaxContent').css({'overflow': 'hidden', 'position': 'static'});
 			return false;
 		}
 	});


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3229400725/97926?viewId=3808239

## Summary

Fixed a layout issue with the Process Feeds modal that occurred when a form had enough feeds to require scrolling. Clicking a feed near the bottom of the list caused the modal to render incorrectly due to `position: relative` being applied to `#TB_ajaxContent` by GF core styles. This caused the scroll offset to influence the modal's positioning.

Fix: Updated this with `position: static` via JS at the point where the modal is opened, alongside the existing `overflow: hidden` rule  that is already applied to that element.

Before:
![feed-forge-issue](https://github.com/user-attachments/assets/a8275fb9-6d8b-415d-ad48-ee7d504dad7c)

After:
![feed-forge-fix](https://github.com/user-attachments/assets/0a7daa57-8ac1-4ca8-84db-405260ecf3d5)


## Checklist

- [ ] Updated customer telling them that a fix/addition is in the works.
- [ ] Added/Improved Cypress tests or a note under _Summary_ why tests are not included in the PR.
- [x] Added a link to this PR in the Help Scout ticket(s) in the form of a note
- [ ] Added/updated hook documentation if applicable.
- [ ] Sent a [packed build](https://www.notion.so/gravitywiz/GWiz-Builder-de063e85494e4a8aace9994a3ef793f9#9de8bd246edb4d108324e5eb32b4d597) of this PR/branch for the customer to test.
